### PR TITLE
Add unit declarator to module, class and grammar declarations

### DIFF
--- a/lib/Acme/DSON.pm
+++ b/lib/Acme/DSON.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module Acme::DSON;
+unit module Acme::DSON;
 
 use Acme::DSON::Actions;
 use Acme::DSON::Grammar;

--- a/lib/Acme/DSON/Actions.pm
+++ b/lib/Acme/DSON/Actions.pm
@@ -1,6 +1,6 @@
 use v6;
 use JSON::Tiny::Actions;
-class Acme::DSON::Actions is JSON::Tiny::Actions;
+unit class Acme::DSON::Actions is JSON::Tiny::Actions;
 
 method value:sym<number>($/) {
     my $result = :8(~$/);

--- a/lib/Acme/DSON/Grammar.pm
+++ b/lib/Acme/DSON/Grammar.pm
@@ -1,6 +1,6 @@
 use v6;
 use JSON::Tiny::Grammar;
-grammar Acme::DSON::Grammar is JSON::Tiny::Grammar;
+unit grammar Acme::DSON::Grammar is JSON::Tiny::Grammar;
 
 rule object    { 'such' ~ 'wow' <pairlist> }
 rule pairlist  { <pair> * % <[,.!?]> }


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.